### PR TITLE
Bump org.springframework.boot til 3.4.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    id("org.springframework.boot") version "3.3.5"
+    id("org.springframework.boot") version "3.4.0"
     id("io.spring.dependency-management") version "1.1.6"
     id("org.jlleitschuh.gradle.ktlint") version "12.1.2"
     kotlin("jvm") version "2.0.21"

--- a/src/main/kotlin/no/nav/helse/flex/cronjob/LeaderElection.kt
+++ b/src/main/kotlin/no/nav/helse/flex/cronjob/LeaderElection.kt
@@ -30,7 +30,7 @@ class LeaderElection(
         val hostname: String = InetAddress.getLocalHost().hostName
 
         val uriString =
-            UriComponentsBuilder.fromHttpUrl(getHttpPath(electorPath))
+            UriComponentsBuilder.fromUriString(getHttpPath(electorPath))
                 .toUriString()
         val result =
             plainTextUtf8RestTemplate

--- a/src/test/kotlin/no/nav/helse/flex/FellesTestOppsett.kt
+++ b/src/test/kotlin/no/nav/helse/flex/FellesTestOppsett.kt
@@ -16,8 +16,8 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.testcontainers.containers.KafkaContainer
 import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.kafka.KafkaContainer
 import org.testcontainers.utility.DockerImageName
 import java.time.OffsetDateTime
 
@@ -50,7 +50,7 @@ abstract class FellesTestOppsett {
                 System.setProperty("spring.datasource.password", it.password)
             }
 
-            KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.1")).also {
+            KafkaContainer(DockerImageName.parse("apache/kafka-native")).also {
                 it.start()
                 System.setProperty("KAFKA_BROKERS", it.bootstrapServers)
             }


### PR DESCRIPTION
Bruk apache/kafka-native i stedet for confluentinc/cp-kafka for mindre image og
raskere oppstart.
